### PR TITLE
Feature: implement nonce for creating payment intent

### DIFF
--- a/src/DonationBlock.php
+++ b/src/DonationBlock.php
@@ -38,6 +38,9 @@ class DonationBlock
         if (!is_admin()) {
             wp_enqueue_script('donation-form-block-script');
             wp_enqueue_script('donation-form-block-stripe-js');
+            wp_localize_script('donation-form-block-stripe-js', 'donationFormBlock', [
+                'nonce' => wp_create_nonce('donation-form-block'),
+            ]);
         }
 
         $stripeData = StripeData::fromOption();

--- a/src/Stripe/DataTransferObjects/PaymentIntentForm.php
+++ b/src/Stripe/DataTransferObjects/PaymentIntentForm.php
@@ -31,6 +31,11 @@ class PaymentIntentForm
      */
     public $liveMode;
 
+    /**
+     * @var string
+     */
+    public $nonce;
+
     public static function fromArray(array $data): self
     {
         $object = new self();
@@ -39,6 +44,7 @@ class PaymentIntentForm
         $object->email = $data['email'];
         $object->amount = $data['amount'];
         $object->liveMode = $data['liveMode'];
+        $object->nonce = $data['nonce'];
         return $object;
     }
 }

--- a/src/donationForm.js
+++ b/src/donationForm.js
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useState} from '@wordpress/element';
+import {useMemo, useRef, useState} from '@wordpress/element';
 import cx from 'classnames';
 import {__} from '@wordpress/i18n';
 import CurrencyInput from 'react-currency-input-field';
@@ -30,9 +30,9 @@ const DonationForm = (props) => {
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
     const [email, setEmail] = useState('');
-    const [error, setError] = useState(false);
     const [handledIntent, setHandledIntent] = useState(null);
-    const [errorMessage, setErrorMessage] = useState([]);
+    const [errorFields, setErrorFields] = useState([]);
+    const [errorMessage, setErrorMessage] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
     const [paymentStatus, setPaymentStatus] = useState({
         status: '',
@@ -80,15 +80,19 @@ const DonationForm = (props) => {
                 nonce: window.donationFormBlock.nonce,
             })
             .then(function (response) {
+                const data = response.data.data;
                 // 🧐 Validation.
-                if (response.data.data.error) {
-                    setError(true);
+                if (data.error) {
                     setIsLoading(false);
-                    setErrorMessage(response.data.data.fields);
+                    if (data.message) {
+                        setErrorMessage(data.message);
+                    } else {
+                        setErrorFields(data.fields);
+                    }
                 } else {
                     setStep(2);
                     // 🤗 Proceed with Stripe.
-                    const clientSecret = response.data.data.clientSecret;
+                    const clientSecret = data.clientSecret;
                     const appearance = {
                         theme: 'stripe',
                         variables: {
@@ -133,11 +137,9 @@ const DonationForm = (props) => {
         });
 
         if (error.type === 'card_error' || error.type === 'validation_error') {
-            setError(true);
-            setErrorMessage(error.message);
+            setErrorFields(error.message);
         } else {
-            setError(true);
-            setErrorMessage('An unexpected error occurred.');
+            setErrorFields('An unexpected error occurred.');
         }
         setIsLoading(false);
     };
@@ -378,24 +380,14 @@ const DonationForm = (props) => {
                                 </div>
                                 {
                                     // 🙅‍ Validation error message (if any).
-                                    error &&
-                                        errorMessage.map((error, index) => {
-                                            return (
-                                                <div
-                                                    key={index}
-                                                    className={`donation-form-notice ${css(
-                                                        styles.noticeBase,
-                                                        styles.noticeValidationError
-                                                    )}`}
-                                                >
-                                                    <ErrorIcon className={css(styles.noticeIcon)} />
-                                                    <p className={css(styles.formParagraph, styles.noticeParagraph)}>
-                                                        {error.message}
-                                                    </p>
-                                                </div>
-                                            );
-                                        })
+                                    errorFields.length > 0 &&
+                                        errorFields.map((error, index) => (
+                                            <ErrorMessage key={index} styles={styles}>
+                                                {error.message}
+                                            </ErrorMessage>
+                                        ))
                                 }
+                                {errorMessage && <ErrorMessage styles={styles}>{errorMessage}</ErrorMessage>}
                             </form>
                         </>
                     )}
@@ -414,19 +406,6 @@ const DonationForm = (props) => {
                             </div>
                             <form onSubmit={handlePaymentSubmit}>
                                 <div className={`donation-form-payment-intent ${css(styles.stripePaymentWrap)}`}></div>
-                                {error && (
-                                    <div
-                                        className={`donation-form-notice ${css(
-                                            styles.noticeBase,
-                                            styles.noticeValidationError
-                                        )}`}
-                                    >
-                                        <ErrorIcon className={css(styles.noticeIcon)} />
-                                        <p className={css(styles.formParagraph, styles.noticeParagraph)}>
-                                            {errorMessage}
-                                        </p>
-                                    </div>
-                                )}
                                 <button
                                     className={`donation-form-submit ${css(
                                         styles.buttonPrimary,
@@ -600,5 +579,14 @@ const DonationForm = (props) => {
 DonationForm.defaultProps = {
     attributes: [],
 };
+
+function ErrorMessage({children, styles}) {
+    return (
+        <div className={`donation-form-notice ${css(styles.noticeBase, styles.noticeValidationError)}`}>
+            <ErrorIcon className={css(styles.noticeIcon)} />
+            <p className={css(styles.formParagraph, styles.noticeParagraph)}>{children}</p>
+        </div>
+    );
+}
 
 export default DonationForm;

--- a/src/donationForm.js
+++ b/src/donationForm.js
@@ -77,6 +77,7 @@ const DonationForm = (props) => {
                 lastName: lastName,
                 email: email,
                 liveMode: props.attributes.liveMode,
+                nonce: window.donationFormBlock.nonce,
             })
             .then(function (response) {
                 // 🧐 Validation.

--- a/src/donationForm.js
+++ b/src/donationForm.js
@@ -58,6 +58,12 @@ const DonationForm = (props) => {
         setDonationAmount(amount);
     };
 
+    const resetForm = () => {
+        setErrorMessage(null);
+        setErrorFields([]);
+        setStep(1);
+    };
+
     // 🤠 Handle the first step of the form.
     const handleAmountSubmit = (e) => {
         e.preventDefault();
@@ -137,9 +143,9 @@ const DonationForm = (props) => {
         });
 
         if (error.type === 'card_error' || error.type === 'validation_error') {
-            setErrorFields(error.message);
+            setErrorMessage(error.message);
         } else {
-            setErrorFields('An unexpected error occurred.');
+            setErrorMessage('An unexpected error occurred.');
         }
         setIsLoading(false);
     };
@@ -406,6 +412,7 @@ const DonationForm = (props) => {
                             </div>
                             <form onSubmit={handlePaymentSubmit}>
                                 <div className={`donation-form-payment-intent ${css(styles.stripePaymentWrap)}`}></div>
+                                {errorMessage && <ErrorMessage styles={styles}>{errorMessage}</ErrorMessage>}
                                 <button
                                     className={`donation-form-submit ${css(
                                         styles.buttonPrimary,
@@ -447,13 +454,7 @@ const DonationForm = (props) => {
                                 </>
                             )}
                             {'' !== paymentStatus.status && true === paymentStatus.error && (
-                                // Error message.
-                                <div className={`donation-form-notice ${css(styles.noticeBase)}`}>
-                                    <AlertIcon className={css(styles.noticeIcon)} />
-                                    <p className={css(styles.formParagraph, styles.noticeParagraph)}>
-                                        {paymentStatus.message}
-                                    </p>
-                                </div>
+                                <ErrorMessage styles={styles}>{paymentStatus.message}</ErrorMessage>
                             )}
                             <div className={`donation-receipt-details`}>
                                 <p className={`donation-receipt-heading ${css(styles.donationReceiptDetails)}`}>
@@ -555,7 +556,7 @@ const DonationForm = (props) => {
                                     styles.donateBtn,
                                     styles.giveAgainBtn
                                 )}`}
-                                onClick={() => setStep(1)}
+                                onClick={resetForm}
                             >
                                 {__('Give Again', 'donation-form-block')}
                                 <CaretIcon className={css(styles.donateBtnIcon)} />


### PR DESCRIPTION
Resolves #1 

## Description

This adds a nonce to creating a Payment Intent, protecting sites from malicious abuse of the endpoint.

As part of this, I also fixed how error messages are displayed, differentiating between the server sending a single message versus an array of fields with errors.

## Affects

When the form is submitted and a payment intent is created to display the CC fields.

## Testing Instructions

Just make a donation. If it works, the nonce works.

To test the errors go into the `PaymentIntentRequest` class and force the errors to happen.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

