### PR TITLE
Update WP version compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Donation Form Block for Stripe ===
 Contributors:      givewp, dlocc, jasontheadams, webdevmattcrom
 Tags:              donation, donate, stripe, fundraise, block
-Tested up to:      5.9.0
+Tested up to:      5.9
 Stable tag:        1.0.1
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
By putting `5.9.0` in "Tested up to" the admin will show that the plugin is NOT compatible with any minor point releases. If we simply put `5.9` it will prevent that notice from appearing.

![image](https://user-images.githubusercontent.com/930724/157651590-cea6d765-ced9-48b8-99bf-735f60f0b508.png)
