### PR TITLE
Add Stripe style focus effects for input fields for consistency

### DIFF
--- a/src/frontendStyles.js
+++ b/src/frontendStyles.js
@@ -6,6 +6,7 @@ import color from 'color';
  */
 export default class StyleSheetFactory {
     static getSheet(props) {
+
         return StyleSheet.create({
             formContainer: {
                 backgroundColor: '#fff',
@@ -190,6 +191,11 @@ export default class StyleSheetFactory {
                 lineHeight: '20px',
                 height: '55px',
                 width: '100%',
+                transition: 'background 0.15s ease, border 0.15s ease, box-shadow 0.15s ease, color 0.15s ease',
+                ':focus': {
+                    borderColor: `${color(props.attributes.color).alpha(0.50)}`,
+                    boxShadow: `inset 0px 1.2px 6.3px rgba(0, 0, 0, 0.15), 0 0 0 3px ${color(props.attributes.color).alpha(0.25)}, 0 1px 1px 0 rgba(0, 0, 0, 0.08)`
+                }
             },
             textFieldIcon: {
                 paddingLeft: '45px',
@@ -225,7 +231,7 @@ export default class StyleSheetFactory {
                 fontSize: '36px',
                 padding: '0 20px',
                 letterSpacing: '0',
-                boxShadow: 'none',
+                boxShadow: 'inset 0px 1.2px 6.3px rgba(0, 0, 0, 0.15)',
                 border: '2px solid #424242',
                 borderRadius: '8px',
                 textAlign: 'right',
@@ -233,7 +239,11 @@ export default class StyleSheetFactory {
                 lineHeight: '1',
                 boxSizing: 'border-box',
                 color: '#333',
-                ':hover': {},
+                transition: 'background 0.15s ease, border 0.15s ease, box-shadow 0.15s ease, color 0.15s ease',
+                ':focus': {
+                    borderColor: `${color(props.attributes.color).alpha(0.50)}`,
+                    boxShadow: `inset 0px 1.2px 6.3px rgba(0, 0, 0, 0.15), 0 0 0 3px ${color(props.attributes.color).alpha(0.25)}, 0 1px 1px 0 rgba(0, 0, 0, 0.08)`
+                }
             },
             secureFooter: {
                 display: 'flex',


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #13 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds similar dynamic CSS that Stripe uses to replicate their field's focus effects.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

First step fields.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![2022-04-18_14-45-56 (1)](https://user-images.githubusercontent.com/1571635/163883072-72ddd9cf-3eed-40c5-a7df-a1e21da49a32.gif)


## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

- Check to ensure colors and transitions match between the block and Stripe's fields.
